### PR TITLE
iOS14で動作しない #5 修正

### DIFF
--- a/AllowsHitTestingSample/ContentView.swift
+++ b/AllowsHitTestingSample/ContentView.swift
@@ -10,42 +10,43 @@ import SwiftUI
 
 struct ContentView: View {
 
-    @State private var allowsHitTesting = true
+    @State private var allowsDoubleTap = true
     @State private var isDark = false
 
     var body: some View {
+        content
+            .contentShape(Rectangle())
+            .padding()
+            .foregroundColor(
+                Color(isDark ? .systemBackground : .label)
+            )
+            .gesture(
+                allowsDoubleTap
+                    ? TapGesture(count: 2).onEnded { isDark.toggle() }
+                    // Tapを無視したい場合は、onEndedで何もしないTapGestureを返す
+                    : TapGesture().onEnded({})
+            )
+            .background(
+                Color(isDark ? .label : .systemBackground)
+                    .edgesIgnoringSafeArea(.all)
+            )
+    }
 
+    private var content: some View {
         VStack {
             Toggle(
-                "allowsHitTestingのON / OFF",
-                isOn: $allowsHitTesting
+                "allowsDoubleTapのON / OFF",
+                isOn: $allowsDoubleTap
             )
 
             Divider()
 
-            Text("allowsHitTestingがONのときは、ダブルタップで背景色が変化します。")
+            Text("allowsDoubleTapがONのときは、ダブルタップで背景色が変化します。")
                 .frame(
                     maxWidth: .infinity,
                     maxHeight: .infinity
                 )
         }
-        .contentShape(Rectangle())
-        .padding()
-        .foregroundColor(
-            Color(isDark ? .systemBackground : .label)
-        )
-        .allowsHitTesting(allowsHitTesting)
-        .gesture(
-            TapGesture(count: 2)
-                .onEnded {
-                    self.isDark.toggle()
-                }
-        )
-        .background(
-            Color(isDark ? .label : .systemBackground)
-                .edgesIgnoringSafeArea(.all)
-        )
-        .disabled(!allowsHitTesting)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # swiftui-allows-hit-testing-sample
+## iOS14
+iOS14から `allowsHitTesting()` を利用する方法だと `Toggle` も操作不可になるようになった。
+iOS13と同様の挙動を実現するには、disableな場合にonEnded等で何もしないクロージャーを返すようにする。
 
+詳細は [ContentView.swift](https://github.com/taguchi-k/swiftui-allows-hit-testing-sample/blob/master/AllowsHitTestingSample/ContentView.swift) 参照
+
+## iOS13
 `allowsHitTesting()` を利用して、 `Gesture` が発火するかどうかをハンドリングするサンプル
 
 * `Toggle` がONのときは `Text` のViewをタップすると背景色が切り替わる

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 iOS14から `allowsHitTesting()` を利用する方法だと `Toggle` も操作不可になるようになった。
 iOS13と同様の挙動を実現するには、disableな場合にonEnded等で何もしないクロージャーを返すようにする。
 
+![iOS14](https://user-images.githubusercontent.com/17519073/105905281-9902e800-6065-11eb-9d40-94c327aad77a.gif)
+
+
 詳細は [ContentView.swift](https://github.com/taguchi-k/swiftui-allows-hit-testing-sample/blob/master/AllowsHitTestingSample/ContentView.swift) 参照
 
 ## iOS13


### PR DESCRIPTION
Bug fix #5 

## やったこと
* Tapを無視したい場合は、onEndedで何もしないTapGestureを返すようにした

## 動作
https://user-images.githubusercontent.com/17519073/105904949-301b7000-6065-11eb-970f-712bc567a9c8.mov

